### PR TITLE
カート追加時のCSRF対策 #9

### DIFF
--- a/lib/view/top.php
+++ b/lib/view/top.php
@@ -38,6 +38,8 @@
 							<form action="<?php echo $_SERVER['PHP_SELF']?>" method="post">
 								<input type="hidden" name="id"
 									value="<?php echo $value['id']; ?>">
+									<input type="hidden" name="token"
+									value="<?php echo $_SESSION['token']; ?>">
 								<button type="submit" class="btn btn-primary cart-btn">カートに入れる</button>
 							</form>
 <?php } else { ?>

--- a/webroot/top.php
+++ b/webroot/top.php
@@ -12,6 +12,7 @@ require_once DIR_MODEL . 'item.php';
 
 {
 	session_start();
+	make_token();
 
 	$db = db_connect();
 	$response = array();
@@ -20,6 +21,18 @@ require_once DIR_MODEL . 'item.php';
 	$response['items'] = item_list($db);
 
 	require_once DIR_VIEW  . 'top.php';
+}
+
+/**
+ * getアクセス時のみtokenを発行してsessionに保存
+ */
+function make_token() {
+    if ($_SERVER['REQUEST_METHOD'] !== 'GET') {
+        return;
+    }
+
+    $token = sha1(uniqid(mt_rand(), true));
+    $_SESSION['token'] = $token;
 }
 
 /**
@@ -38,9 +51,13 @@ function __regist($db, &$response) {
 		return;
 	}
 
-	if (cart_regist($db, $_SESSION['user']['id'], $_POST['id'])) {
-		$response['result_msg'] = 'カートに登録しました。';
-		return;
+	if (isset($_POST['token'])&& $_POST["token"] === $_SESSION['token']) {
+	    if (cart_regist($db, $_SESSION['user']['id'], $_POST['id'])) {
+	        $response['result_msg'] = 'カートに登録しました。';
+	        return;
+	    }
+	}else{
+	    $response['error_msg'] = '不正なアクセスです。';
 	}
 
 	$response['error_msg'] = 'カート登録に失敗しました。';


### PR DESCRIPTION
# 概要
カート追加時のCSRF対策

# 変更内容
- トップページアクセス時にトークンを発行
- トップページからカートに追加する際にCSRF対策をほどこす

# 影響範囲
- トップページ
- カートページ

# 補足
- #3のブランチが古くなっていたので新しいissueを作ってプルリクし直しました。