### PR TITLE
注文履歴画面と購入明細書/領収書ページを表示する #13

### DIFF
--- a/lib/model/cart.php
+++ b/lib/model/cart.php
@@ -12,12 +12,24 @@
  * @return boolean
  */
 function cart_is_exists_item($db, $user_id, $item_id) {
-	$sql = <<<EOD
-SELECT item_id, amount FROM carts
- WHERE user_id = {$user_id} AND item_id = {$item_id}
-EOD;
+    $stmt = $db->prepare(
+'SELECT item_id, amount FROM carts
+ WHERE user_id = ? AND item_id = ?');
 
-	$cart = db_select($db, $sql);
+    $stmt->bindValue(1,(int)$user_id,PDO::PARAM_INT);
+    $stmt->bindValue(2,(int)$item_id,PDO::PARAM_INT);
+    $stmt->execute();
+    if ($stmt->rowCount() === 0) {
+        return array();
+    }
+
+    $rows = $stmt->fetchAll(PDO::FETCH_ASSOC);
+    if (empty($rows)) {
+        return null;
+    }
+    return $rows[0];
+
+    $cart = $rows[0];
 	return empty($cart) === false;
 }
 
@@ -27,17 +39,25 @@ EOD;
  * @return int | NULL
  */
 function cart_total_price($db, $user_id) {
-	$sql = <<<EOD
-SELECT sum(price * amount) as total_price
+
+    $stmt = $db->prepare(
+'SELECT sum(price * amount) as total_price
  FROM carts JOIN items
  ON carts.item_id = items.id
- WHERE items.status = 1 AND user_id = {$user_id}
-EOD;
-	$row = db_select_one($db, $sql);
-	if (empty($row)) {
-		return null;
-	}
-	return $row['total_price'];
+ WHERE items.status = 1 AND user_id = ?');
+
+    $stmt->bindValue(1,(int)$user_id,PDO::PARAM_INT);
+    $stmt->execute();
+    if ($stmt->rowCount() === 0) {
+        return array();
+    }
+
+    $row = $stmt->fetchAll(PDO::FETCH_ASSOC);
+    if (empty($row)) {
+        return null;
+    }
+
+	return $row[0]['total_price'];
 }
 
 /**
@@ -46,13 +66,25 @@ EOD;
  * @return array
  */
 function cart_list($db, $user_id) {
-	$sql = <<<EOD
- SELECT carts.id, user_id, item_id, name, price, img, stock, status, amount, (price * amount) as amount_price
+
+    $stmt = $db->prepare(
+ 'SELECT carts.id, user_id, item_id, name, price, img, stock, status, amount, (price * amount) as amount_price
  FROM carts JOIN items
  ON carts.item_id = items.id
- WHERE items.status = 1 AND user_id = {$user_id}
-EOD;
-	return db_select($db, $sql);
+ WHERE items.status = 1 AND user_id = ?');
+
+    $stmt->bindValue(1,(int)$user_id,PDO::PARAM_INT);
+    $stmt->execute();
+    if ($stmt->rowCount() === 0) {
+        return array();
+    }
+
+    $rows = $stmt->fetchAll(PDO::FETCH_ASSOC);
+    if (empty($rows)) {
+        return null;
+    }
+    return $rows;
+
 }
 
 /**
@@ -69,27 +101,20 @@ function cart_regist($db, $user_id, $item_id) {
 'UPDATE carts
  SET amount = amount + 1 , update_date = NOW()
  WHERE user_id = ? AND item_id = ?');
-	    $stmt->bindValue(1,$user_id,PDO::PARAM_INT);
-	    $stmt->bindValue(2,$item_id,PDO::PARAM_INT);
+	    $stmt->bindValue(1,(int)$user_id,PDO::PARAM_INT);
+	    $stmt->bindValue(2,(int)$item_id,PDO::PARAM_INT);
 
 	    return $stmt->execute();
 	    if ($stmt->rowCount() === 0) {
 	        return false;
 	    }
 
-		/*$sql = <<<EOD
-UPDATE carts
- SET amount = amount + 1 , update_date = NOW()
- WHERE user_id = {$user_id} AND item_id = {$item_id}
-EOD;
-		return db_update($db, $sql);*/
-
 	} else {
 	    $stmt = $db->prepare(
 'INSERT INTO carts (user_id, item_id, amount, create_date, update_date)
 VALUES (?,?, 1, NOW(), NOW())');
-	    $stmt->bindValue(1,$user_id,PDO::PARAM_INT);
-	    $stmt->bindValue(2,$item_id,PDO::PARAM_INT);
+	    $stmt->bindValue(1,(int)$user_id,PDO::PARAM_INT);
+	    $stmt->bindValue(2,(int)$item_id,PDO::PARAM_INT);
 
 	    return $stmt->execute();
 	    if ($stmt->rowCount() === 0) {
@@ -112,9 +137,9 @@ function cart_update($db, $id, $user_id, $amount) {
 'UPDATE carts
  SET amount = ?, update_date = NOW()
  WHERE id = ? AND user_id = ?');
-    $stmt->bindValue(1,$amount,PDO::PARAM_INT);
-    $stmt->bindValue(2,$id,PDO::PARAM_INT);
-    $stmt->bindValue(3,$user_id,PDO::PARAM_INT);
+    $stmt->bindValue(1,(int)$amount,PDO::PARAM_INT);
+    $stmt->bindValue(2,(int)$id,PDO::PARAM_INT);
+    $stmt->bindValue(3,(int)$user_id,PDO::PARAM_INT);
 
     return $stmt->execute();
     if ($stmt->rowCount() === 0) {
@@ -132,8 +157,8 @@ function cart_delete($db, $id, $user_id) {
     $stmt = $db->prepare(
 'DELETE FROM carts
  WHERE id = ? AND user_id = ?');
-    $stmt->bindValue(1,$id,PDO::PARAM_INT);
-    $stmt->bindValue(2,$user_id,PDO::PARAM_INT);
+    $stmt->bindValue(1,(int)$id,PDO::PARAM_INT);
+    $stmt->bindValue(2,(int)$user_id,PDO::PARAM_INT);
 
     return $stmt->execute();
     if ($stmt->rowCount() === 0) {
@@ -149,7 +174,7 @@ function cart_delete($db, $id, $user_id) {
 function cart_clear($db, $user_id) {
     $stmt = $db->prepare(
     'DELETE FROM carts WHERE user_id =?');
-    $stmt->bindValue(1,$user_id,PDO::PARAM_INT);
+    $stmt->bindValue(1,(int)$user_id,PDO::PARAM_INT);
 
     return $stmt->execute();
     if ($stmt->rowCount() === 0) {
@@ -163,7 +188,7 @@ function in_order_histories($db, $user_id){
     $stmt = $db->prepare(
     'INSERT INTO order_histories (user_id, bought_at)
     VALUES (?,NOW())');
-    $stmt->bindValue(1,$user_id,PDO::PARAM_INT);
+    $stmt->bindValue(1,(int)$user_id,PDO::PARAM_INT);
 
     return $stmt->execute();
     if ($stmt->rowCount() === 0) {
@@ -175,10 +200,10 @@ function in_log_items($db,$last_id,$name,$price,$amount){
     $stmt = $db->prepare(
     'INSERT INTO log_items (order_history_id, item_name, price, amount)
     VALUES (?,?,?,?)');
-    $stmt->bindValue(1,$last_id,PDO::PARAM_INT);
+    $stmt->bindValue(1,(int)$last_id,PDO::PARAM_INT);
     $stmt->bindValue(2,$name,PDO::PARAM_STR);
-    $stmt->bindValue(3,$price,PDO::PARAM_INT);
-    $stmt->bindValue(4,$amount,PDO::PARAM_INT);
+    $stmt->bindValue(3,(int)$price,PDO::PARAM_INT);
+    $stmt->bindValue(4,(int)$amount,PDO::PARAM_INT);
 
     return $stmt->execute();
     if ($stmt->rowCount() === 0) {

--- a/lib/model/item.php
+++ b/lib/model/item.php
@@ -22,9 +22,9 @@ function item_regist($db, $name, $img, $price, $stock, $status) {
 
     $stmt->bindValue(1,$name,PDO::PARAM_STR);
     $stmt->bindValue(2,$img,PDO::PARAM_STR);
-    $stmt->bindValue(3,$price,PDO::PARAM_INT);
-    $stmt->bindValue(4,$stock,PDO::PARAM_INT);
-    $stmt->bindValue(5,$status,PDO::PARAM_INT);
+    $stmt->bindValue(3,(int)$price,PDO::PARAM_INT);
+    $stmt->bindValue(4,(int)$stock,PDO::PARAM_INT);
+    $stmt->bindValue(5,(int)$status,PDO::PARAM_INT);
 
     return $stmt->execute();
     if ($stmt->rowCount() === 0) {
@@ -45,7 +45,7 @@ function item_delete($db, $id) {
 	}
 	$stmt = $db->prepare(
 	'DELETE FROM items WHERE id = ?');
-	$stmt->bindValue(1,$id,PDO::PARAM_STR);
+	$stmt->bindValue(1,(int)$id,PDO::PARAM_INT);
 
 	return $stmt->execute();
 	if ($stmt->rowCount() === 0) {
@@ -77,13 +77,19 @@ EOD;
  * @return NULL|mixed
  */
 function item_get($db, $id) {
-	$sql = <<<EOD
- SELECT id, name, price, img, stock, status, create_date, update_date
+    $stmt = $db->prepare('SELECT id, name, price, img, stock, status, create_date, update_date
  FROM items
- WHERE id = {$id}
-EOD;
-
-	return db_select_one($db, $sql);
+ WHERE id = ?');
+    $stmt->bindValue(1,(int)$id,PDO::PARAM_INT);
+    $stmt->execute();
+    if ($stmt->rowCount() === 0) {
+        return array();
+    }
+    $rows = $stmt->fetchAll(PDO::FETCH_ASSOC);
+    if (empty($rows)) {
+        return null;
+    }
+    return $rows;
 }
 
 /**
@@ -97,8 +103,8 @@ function item_update_stock($db, $id, $stock) {
  'UPDATE items
  SET stock = ?, update_date = NOW()
  WHERE id = ?');
-    $stmt->bindValue(1,$stock,PDO::PARAM_STR);
-    $stmt->bindValue(2,$id,PDO::PARAM_STR);
+    $stmt->bindValue(1,(int)$stock,PDO::PARAM_INT);
+    $stmt->bindValue(2,(int)$id,PDO::PARAM_INT);
 
     return $stmt->execute();
     if ($stmt->rowCount() === 0) {
@@ -118,8 +124,8 @@ function item_update_saled($db, $id, $amount) {
  'UPDATE items
  SET stock = stock - ?, update_date = NOW()
  WHERE id = ?');
-    $stmt->bindValue(1,$amount,PDO::PARAM_STR);
-    $stmt->bindValue(2,$id,PDO::PARAM_STR);
+    $stmt->bindValue(1,(int)$amount,PDO::PARAM_INT);
+    $stmt->bindValue(2,(int)$id,PDO::PARAM_INT);
 
     return $stmt->execute();
     if ($stmt->rowCount() === 0) {
@@ -139,8 +145,8 @@ function item_update_status($db, $id, $status) {
 'UPDATE items
  SET status = ?, update_date = NOW()
  WHERE id = ?');
-    $stmt->bindValue(1,$status,PDO::PARAM_INT);
-    $stmt->bindValue(2,$id,PDO::PARAM_STR);
+    $stmt->bindValue(1,(int)$status,PDO::PARAM_INT);
+    $stmt->bindValue(2,(int)$id,PDO::PARAM_INT);
 
     return $stmt->execute();
     if ($stmt->rowCount() === 0) {

--- a/lib/model/user.php
+++ b/lib/model/user.php
@@ -15,7 +15,7 @@ function user_get_login($db, $login_id, $password) {
 	$stmt = $db->prepare('SELECT id, login_id, password, is_admin, create_date, update_date
                         FROM users
                         WHERE login_id = ? AND password = ?');
-	$stmt->bindValue(1,$login_id,PDO::PARAM_STR);
+	$stmt->bindValue(1,(int)$login_id,PDO::PARAM_INT);
 	$stmt->bindValue(2,sha1($password),PDO::PARAM_STR);
 	$stmt->execute();
 	if ($stmt->rowCount() === 0) {
@@ -26,6 +26,7 @@ function user_get_login($db, $login_id, $password) {
 	    return null;
 	}
 	return $rows[0];
+	//return $rows;
 }
 
 /**
@@ -37,10 +38,12 @@ function user_get($db, $id) {
     $stmt = $db->prepare('SELECT id, login_id, password, is_admin, create_date, update_date
                             FROM users
                             WHERE id = ?');
-    $stmt->bindValue(1,$id,PDO::PARAM_STR);
+    $stmt->bindValue(1,(int)$id,PDO::PARAM_INT);
     $stmt->execute();
+    if ($stmt->rowCount() === 0) {
+        return array();
+    }
     $rows = $stmt->fetchAll(PDO::FETCH_ASSOC);
-    //return $rows;
     if (empty($rows)) {
         return null;
     }

--- a/lib/view/element/output_navber.php
+++ b/lib/view/element/output_navber.php
@@ -18,6 +18,8 @@
 				<li class="nav-item"><a class="text-white nav-link" href="./top.php">ホーム</a></li>
 				<li class="nav-item"><a class="text-white nav-link"
 					href="./cart.php">カート</a></li>
+					<li class="nav-item"><a class="text-white nav-link"
+					href="./history.php">履歴</a></li>
 <?php if (empty($_SESSION['user'])) { ?>
 				<li class="nav-item"><a class="text-white nav-link"
 					href="./login.php">ログイン</a></li>

--- a/lib/view/history.php
+++ b/lib/view/history.php
@@ -46,7 +46,7 @@ $index ++;
 						<tr class="<?php echo (0 === ($index % 2)) ? 'stripe' : '' ; ?>">
 								<td colspan="2">注文番号:<?php echo $key['order_history_id']?></td>
 								<td colspan="2" align = right>
-								<form action="./receipt.php" method="post">
+								<form action="./receipt.php" method="get">
 									<button type="submit" class="btn btn-success btn-sm">領収書／購入明細書</button>
 									<input type="hidden" name="id"
 										value="<?php echo $key['order_history_id']; ?>">

--- a/lib/view/history.php
+++ b/lib/view/history.php
@@ -39,22 +39,25 @@
 					</thead>
 					<tbody>
 <?php
-var_dump($response['history']);
-foreach ( $response['history'] as $key => $value ) {
+pre($responce['history']);
+foreach ($response['history'] as $key ) {
+    var_dump($key);
 ?>
 						<tr class="<?php echo (0 === ($key % 2)) ? 'stripe' : '' ; ?>">
-								<td colspan="3">注文番号:<?php echo $value['order_history_id']?></td>
+								<td colspan="3">注文番号:<?php echo $key['order_history_id']?></td>
 								<td>
 								<form action="./receipt.php" method="post">
-									<button type="submit" class="btn btn-danger btn-sm">領収書／購入明細書</button>
+									<button type="submit" class="btn btn-success btn-sm">領収書／購入明細書</button>
 									<input type="hidden" name="id"
-										value="<?php echo $value['order_history_id']; ?>">
+										value="<?php echo $key['order_history_id']; ?>">
+										<input type="hidden" name="time"
+										value="<?php echo $key['bought_at']; ?>">
 								</form>
 							</td>
 						</tr>
 						<tr class="<?php echo (0 === ($key % 2)) ? 'stripe' : '' ; ?>">
-							<td colspan="3">注文日時:<?php echo $value['bought_at']?></td>
-								<td><?php echo number_format($value['price'])?>円</td>
+							<td colspan="3">注文日時:<?php echo $key['bought_at']?></td>
+								<td><?php echo number_format($key["total_price"])?>円</td>
 						</tr>
 <?php } ?>
 					</tbody>

--- a/lib/view/history.php
+++ b/lib/view/history.php
@@ -34,18 +34,18 @@
 				<table class="table">
 					<thead>
 						<tr>
-							<th colspan="3">注文履歴</th>
+							<th colspan="4">注文履歴</th>
 						</tr>
 					</thead>
 					<tbody>
 <?php
-pre($responce['history']);
+$index = 0;
 foreach ($response['history'] as $key ) {
-    var_dump($key);
+$index ++;
 ?>
-						<tr class="<?php echo (0 === ($key % 2)) ? 'stripe' : '' ; ?>">
-								<td colspan="3">注文番号:<?php echo $key['order_history_id']?></td>
-								<td>
+						<tr class="<?php echo (0 === ($index % 2)) ? 'stripe' : '' ; ?>">
+								<td colspan="2">注文番号:<?php echo $key['order_history_id']?></td>
+								<td colspan="2" align = right>
 								<form action="./receipt.php" method="post">
 									<button type="submit" class="btn btn-success btn-sm">領収書／購入明細書</button>
 									<input type="hidden" name="id"
@@ -55,19 +55,13 @@ foreach ($response['history'] as $key ) {
 								</form>
 							</td>
 						</tr>
-						<tr class="<?php echo (0 === ($key % 2)) ? 'stripe' : '' ; ?>">
-							<td colspan="3">注文日時:<?php echo $key['bought_at']?></td>
-								<td><?php echo number_format($key["total_price"])?>円</td>
+						<tr class="<?php echo (0 === ($index % 2)) ? 'stripe' : '' ; ?>">
+							<td colspan="2">注文日時:<?php echo $key['bought_at']?></td>
+							<td colspan="2" align = right><?php echo number_format($key["total_price"])?>円</td>
 						</tr>
 <?php } ?>
 					</tbody>
-					<tfoot>
-						<tr>
-							<td></td>
-							<td></td>
-						</tr>
 
-					</tfoot>
 				</table>
 			</div>
 		</div>

--- a/lib/view/history.php
+++ b/lib/view/history.php
@@ -1,0 +1,83 @@
+<?php
+/**
+ * @license CC BY-NC-SA 4.0
+ * @license https://creativecommons.org/licenses/by-nc-sa/4.0/deed.ja
+ * @copyright CodeCamp https://codecamp.jp
+ */
+?>
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>注文履歴</title>
+<link href="./assets/bootstrap/dist/css/bootstrap.min.css"
+	rel="stylesheet">
+<link rel="stylesheet" href="./assets/css/style.css">
+
+</head>
+<body>
+<?php require DIR_VIEW_ELEMENT . 'output_navber.php'; ?>
+
+	<div class="container-fluid px-md-3">
+		<div class="row">
+			<div class="col-12">
+				<h1>注文履歴</h1>
+			</div>
+		</div>
+
+<?php require DIR_VIEW_ELEMENT . 'output_message.php'; ?>
+
+<?php if ( !empty($response['history'])) { ?>
+		<div class="col-xs-12 col-md-10 offset-md-1 cart-list">
+			<div class="row">
+				<table class="table">
+					<thead>
+						<tr>
+							<th colspan="3">注文履歴</th>
+						</tr>
+					</thead>
+					<tbody>
+<?php
+var_dump($response['history']);
+foreach ( $response['history'] as $key => $value ) {
+?>
+						<tr class="<?php echo (0 === ($key % 2)) ? 'stripe' : '' ; ?>">
+								<td colspan="3">注文番号:<?php echo $value['order_history_id']?></td>
+								<td>
+								<form action="./receipt.php" method="post">
+									<button type="submit" class="btn btn-danger btn-sm">領収書／購入明細書</button>
+									<input type="hidden" name="id"
+										value="<?php echo $value['order_history_id']; ?>">
+								</form>
+							</td>
+						</tr>
+						<tr class="<?php echo (0 === ($key % 2)) ? 'stripe' : '' ; ?>">
+							<td colspan="3">注文日時:<?php echo $value['bought_at']?></td>
+								<td><?php echo number_format($value['price'])?>円</td>
+						</tr>
+<?php } ?>
+					</tbody>
+					<tfoot>
+						<tr>
+							<td></td>
+							<td></td>
+						</tr>
+
+					</tfoot>
+				</table>
+			</div>
+		</div>
+<?php }?>
+	</div>
+	<!-- /.container -->
+	<script src="./assets/js/jquery/1.12.4/jquery.min.js"></script>
+	<script src="./assets/bootstrap/dist/js/bootstrap.min.js"></script>
+	<script type="text/javascript">
+		function submit_change_amount(id) {
+			document.getElementById('form_select_amount' + id).submit();
+		}
+	</script>
+
+</body>
+</html>

--- a/lib/view/receipt.php
+++ b/lib/view/receipt.php
@@ -33,21 +33,26 @@
 				<table class="table">
 					<thead>
 						<tr>
-							<th colspan="2">注文番号：<?php  echo $order_history_id ?></th>
-							<th colspan="">注文日時：<?php  echo $bought_time ?></th>
+							<th colspan="4">注文番号：<?php  echo $order_history_id ?></th>
+							</tr>
+							<tr>
+							<th colspan="4" align = right>注文日時：<?php  echo $bought_time ?></th>
 
 						</tr>
 					</thead>
 					<tbody>
-<?php foreach ( $response['history'] as $key => $value ) {?>
-						<tr class="<?php echo (0 === ($key % 2)) ? 'stripe' : '' ; ?>">
-								<td colspan="3"><?php echo (htmlspecialchars($value['item_name'], ENT_QUOTES, 'UTF-8'))?></td>
-								<td><?php echo number_format($value['amount'])?>個</td>
-								<td><?php echo number_format($value['price'])?>円</td>
+<?php
+$index = 0;
+foreach ( $response['history'] as $key => $value ) {
+$index ++; ?>
+						<tr class="<?php echo (0 === ($index % 2)) ? 'stripe' : '' ; ?>">
+								<td colspan="2"><?php echo (htmlspecialchars($value['item_name'], ENT_QUOTES, 'UTF-8'))?></td>
+								<td align = right><?php echo number_format($value['amount'])?>個</td>
+								<td align = right><?php echo number_format($value['price'])?>円</td>
 						</tr>
-						<tr class="<?php echo (0 === ($key % 2)) ? 'stripe' : '' ; ?>">
+						<tr class="<?php echo (0 === ($index % 2)) ? 'stripe' : '' ; ?>">
 
-							<td>小計：<?php echo number_format($value['amount_price'])?>円</td>
+							<td colspan="4" align = right>小計：<?php echo number_format($value['amount_price'])?>円</td>
 
 						</tr>
 <?php } ?>
@@ -56,9 +61,9 @@
 						<tr>
 							<td></td>
 							<td></td>
-							<td colspan="5">
+							<td colspan="4" align = right>
 								<div>
-									<span>合計</span> <span><?php echo number_format($sum); ?>円</span>
+									<b><span>合計</span> <span><?php echo number_format($sum); ?>円</span></b>
 								</div>
 							</td>
 						</tr>

--- a/lib/view/receipt.php
+++ b/lib/view/receipt.php
@@ -1,0 +1,106 @@
+<?php
+/**
+ * @license CC BY-NC-SA 4.0
+ * @license https://creativecommons.org/licenses/by-nc-sa/4.0/deed.ja
+ * @copyright CodeCamp https://codecamp.jp
+ */
+?>
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>購入明細書</title>
+<link href="./assets/bootstrap/dist/css/bootstrap.min.css"
+	rel="stylesheet">
+<link rel="stylesheet" href="./assets/css/style.css">
+
+</head>
+<body>
+<?php require DIR_VIEW_ELEMENT . 'output_navber.php'; ?>
+	<div class="container-fluid px-md-3">
+		<div class="row">
+			<div class="col-12">
+				<h1>購入明細書</h1>
+			</div>
+		</div>
+
+<?php require DIR_VIEW_ELEMENT . 'output_message.php'; ?>
+
+<?php if ( !empty($result)) { ?>
+		<div class="col-xs-12 col-md-10 offset-md-1 cart-list">
+			<div class="row">
+				<table class="table">
+					<thead>
+						<tr>
+							<th rowspan="2" style="width: 30%;"></th>
+							<th colspan="3">商品名</th>
+						</tr>
+						<tr>
+							<th>削除</th>
+							<th>価格</th>
+							<th>数量</th>
+						</tr>
+					</thead>
+					<tbody>
+<?php foreach ( $result as $key => $value ) {?>
+						<tr class="<?php echo (0 === ($key % 2)) ? 'stripe' : '' ; ?>">
+							<td rowspan="2"><img class="w-100"
+								src="<?php echo DIR_IMG . $value['img']; ?>"></td>
+								<td colspan="3"><?php echo (htmlspecialchars($value['name'], ENT_QUOTES, 'UTF-8'))?></td>
+						</tr>
+						<tr class="<?php echo (0 === ($key % 2)) ? 'stripe' : '' ; ?>">
+							<td>
+								<form action="<?php echo $_SERVER['PHP_SELF']?>" method="post">
+									<button type="submit" class="btn btn-danger btn-sm">削除</button>
+									<input type="hidden" name="id"
+										value="<?php echo $value['id']; ?>"> <input
+										type="hidden" name="action" value="delete">
+								</form>
+							</td>
+							<td><?php echo number_format($value['price'])?>円</td>
+							<td>
+								<form id="form_select_amount<?php echo $value['id']; ?>"
+									action="<?php echo $_SERVER['PHP_SELF']?>" method="post">
+									<select name="amount"
+										onchange="submit_change_amount(<?php echo $value['id']; ?>)">
+<?php $max_count = 10; if ((int)$value['amount'] > $max_count){$max_count = (int)$value['amount'];}; ?>
+<?php for ($count = 1; $count <= $max_count; $count++)  { ?>
+										<option value="<?php echo $count; ?>"
+											<?php if ((int)$value['amount'] === $count){echo 'selected';}; ?>><?php echo $count;?></option>
+<?php } ?>
+                        </select> <input type="hidden" name="id"
+										value="<?php echo $value['id']; ?>"> <input
+										type="hidden" name="action" value="update">
+								</form>
+							</td>
+						</tr>
+<?php } ?>
+					</tbody>
+					<tfoot>
+						<tr>
+							<td></td>
+							<td></td>
+							<td colspan="2">
+								<div>
+									<span>合計</span> <span><?php echo number_format($response['total_price']); ?>円</span>
+								</div>
+							</td>
+						</tr>
+					</tfoot>
+				</table>
+			</div>
+		</div>
+<?php }?>
+	</div>
+	<!-- /.container -->
+	<script src="./assets/js/jquery/1.12.4/jquery.min.js"></script>
+	<script src="./assets/bootstrap/dist/js/bootstrap.min.js"></script>
+	<script type="text/javascript">
+		function submit_change_amount(id) {
+			document.getElementById('form_select_amount' + id).submit();
+		}
+	</script>
+
+</body>
+</html>

--- a/lib/view/receipt.php
+++ b/lib/view/receipt.php
@@ -27,53 +27,28 @@
 
 <?php require DIR_VIEW_ELEMENT . 'output_message.php'; ?>
 
-<?php if ( !empty($result)) { ?>
+<?php if ( !empty($response['history'])) { ?>
 		<div class="col-xs-12 col-md-10 offset-md-1 cart-list">
 			<div class="row">
 				<table class="table">
 					<thead>
 						<tr>
-							<th rowspan="2" style="width: 30%;"></th>
-							<th colspan="3">商品名</th>
-						</tr>
-						<tr>
-							<th>削除</th>
-							<th>価格</th>
-							<th>数量</th>
+							<th colspan="2">注文番号：<?php  echo $order_history_id ?></th>
+							<th colspan="">注文日時：<?php  echo $bought_time ?></th>
+
 						</tr>
 					</thead>
 					<tbody>
-<?php foreach ( $result as $key => $value ) {?>
+<?php foreach ( $response['history'] as $key => $value ) {?>
 						<tr class="<?php echo (0 === ($key % 2)) ? 'stripe' : '' ; ?>">
-							<td rowspan="2"><img class="w-100"
-								src="<?php echo DIR_IMG . $value['img']; ?>"></td>
-								<td colspan="3"><?php echo (htmlspecialchars($value['name'], ENT_QUOTES, 'UTF-8'))?></td>
+								<td colspan="3"><?php echo (htmlspecialchars($value['item_name'], ENT_QUOTES, 'UTF-8'))?></td>
+								<td><?php echo number_format($value['amount'])?>個</td>
+								<td><?php echo number_format($value['price'])?>円</td>
 						</tr>
 						<tr class="<?php echo (0 === ($key % 2)) ? 'stripe' : '' ; ?>">
-							<td>
-								<form action="<?php echo $_SERVER['PHP_SELF']?>" method="post">
-									<button type="submit" class="btn btn-danger btn-sm">削除</button>
-									<input type="hidden" name="id"
-										value="<?php echo $value['id']; ?>"> <input
-										type="hidden" name="action" value="delete">
-								</form>
-							</td>
-							<td><?php echo number_format($value['price'])?>円</td>
-							<td>
-								<form id="form_select_amount<?php echo $value['id']; ?>"
-									action="<?php echo $_SERVER['PHP_SELF']?>" method="post">
-									<select name="amount"
-										onchange="submit_change_amount(<?php echo $value['id']; ?>)">
-<?php $max_count = 10; if ((int)$value['amount'] > $max_count){$max_count = (int)$value['amount'];}; ?>
-<?php for ($count = 1; $count <= $max_count; $count++)  { ?>
-										<option value="<?php echo $count; ?>"
-											<?php if ((int)$value['amount'] === $count){echo 'selected';}; ?>><?php echo $count;?></option>
-<?php } ?>
-                        </select> <input type="hidden" name="id"
-										value="<?php echo $value['id']; ?>"> <input
-										type="hidden" name="action" value="update">
-								</form>
-							</td>
+
+							<td>小計：<?php echo number_format($value['amount_price'])?>円</td>
+
 						</tr>
 <?php } ?>
 					</tbody>
@@ -81,9 +56,9 @@
 						<tr>
 							<td></td>
 							<td></td>
-							<td colspan="2">
+							<td colspan="5">
 								<div>
-									<span>合計</span> <span><?php echo number_format($response['total_price']); ?>円</span>
+									<span>合計</span> <span><?php echo number_format($sum); ?>円</span>
 								</div>
 							</td>
 						</tr>

--- a/webroot/history.php
+++ b/webroot/history.php
@@ -1,0 +1,115 @@
+<?php
+/**
+ * @license CC BY-NC-SA 4.0
+ * @license https://creativecommons.org/licenses/by-nc-sa/4.0/deed.ja
+ * @copyright CodeCamp https://codecamp.jp
+ */
+require_once '../lib/config/const.php';
+
+require_once DIR_MODEL . 'function.php';
+
+{
+	session_start();
+
+	$response = array();
+	$row = array();
+	$db = db_connect();
+
+	check_logined($db);
+
+	$response['history'] = history_list($db, $_SESSION['user']['id']);
+/*	$row = history_item($db, $_SESSION['user']['id']);
+	foreach($response['history'] as $key){
+	    foreach($row as $rows){
+	        if($key['order_history_id'] === $rows['order_history_id']){
+
+	        }
+	    }
+	}*/
+
+	if (empty($response['history'])) {
+		$response['error_msg'] = '注文履歴はありません';
+	}
+
+	require_once DIR_VIEW . 'history.php';
+}
+
+function history_list($db, $user_id){
+    $stmt = $db->prepare(
+ 'SELECT
+  order_history_id,
+  user_id,
+  bought_at
+FROM
+  order_histories
+  WHERE user_id = ?');
+    $stmt->bindValue(1,(int)$user_id,PDO::PARAM_INT);
+    $stmt->execute();
+    if ($stmt->rowCount() === 0) {
+        return array();
+    }
+
+    $row = $stmt->fetchAll(PDO::FETCH_ASSOC);
+    if (empty($row)) {
+        return null;
+    }
+
+    return $row;
+}
+
+/*function history_total_price($db, $user_id) {
+
+    $stmt = $db->prepare(
+ 'SELECT
+order_history_id
+(price * amount) as total_price
+FROM
+  log_items
+JOIN
+  order_histories
+ ON order_histories.order_history_id = log_items.order_history_id
+ WHERE user_id = ?');
+
+    $stmt->bindValue(1,(int)$user_id,PDO::PARAM_INT);
+    $stmt->execute();
+    if ($stmt->rowCount() === 0) {
+        return array();
+    }
+
+    $row = $stmt->fetchAll(PDO::FETCH_ASSOC);
+    if (empty($row)) {
+        return null;
+    }
+
+    return $row['total_price'];
+}*/
+
+function history_item($db, $user_id){
+    $stmt = $db->prepare(
+ 'SELECT
+  order_histories.order_history_id,
+  order_histories.user_id,
+  order_histories.bought_at,
+  log_items.item_name,
+  log_items.price,
+  log_items.amount,
+  (price * amount) as amount_price
+FROM
+  order_histories
+  INNER JOIN log_items
+  ON order_histories.order_history_id = log_items.order_history_id
+  WHERE  order_histories.user_id = ?');
+    $stmt->bindValue(1,(int)$user_id,PDO::PARAM_INT);
+    $stmt->execute();
+    if ($stmt->rowCount() === 0) {
+        return array();
+    }
+
+    $row = $stmt->fetchAll(PDO::FETCH_ASSOC);
+    if (empty($row)) {
+        return null;
+    }
+
+    return $row;
+
+}

--- a/webroot/history.php
+++ b/webroot/history.php
@@ -28,10 +28,10 @@ require_once DIR_MODEL . 'function.php';
 	        $histories[$order_history_id] = [
 	            'order_history_id' => $row['order_history_id'],
 	            'bought_at' => $row['bought_at'],
-	            'total_price' => $row['price'],
+	            'total_price' => $row['amount_price'],
 	        ];
 	    }else{
-	        $histories[$order_history_id]['total_price'] += $row['price'];
+	        $histories[$order_history_id]['total_price'] += $row['amount_price'];
 	    }
 	}
 	$response['history'] = array_reverse($histories);

--- a/webroot/history.php
+++ b/webroot/history.php
@@ -17,7 +17,7 @@ require_once DIR_MODEL . 'function.php';
 
 	check_logined($db);
 
-	$response['history'] = array_reverse(history_list($db, $_SESSION['user']['id']));
+	$response['history'] = history_list($db, $_SESSION['user']['id']);
 	$rows = history_item($db, $_SESSION['user']['id']);
 
 	$histories =[];
@@ -34,7 +34,7 @@ require_once DIR_MODEL . 'function.php';
 	        $histories[$order_history_id]['total_price'] += $row['price'];
 	    }
 	}
-	$responce['history'] = $histories;
+	$response['history'] = array_reverse($histories);
 
 
 	if (empty($response['history'])) {

--- a/webroot/history.php
+++ b/webroot/history.php
@@ -12,26 +12,43 @@ require_once DIR_MODEL . 'function.php';
 	session_start();
 
 	$response = array();
-	$row = array();
+	$rows = array();
 	$db = db_connect();
 
 	check_logined($db);
 
-	$response['history'] = history_list($db, $_SESSION['user']['id']);
-/*	$row = history_item($db, $_SESSION['user']['id']);
-	foreach($response['history'] as $key){
-	    foreach($row as $rows){
-	        if($key['order_history_id'] === $rows['order_history_id']){
+	$response['history'] = array_reverse(history_list($db, $_SESSION['user']['id']));
+	$rows = history_item($db, $_SESSION['user']['id']);
 
-	        }
+	$histories =[];
+
+	foreach($rows as $row){
+	    $order_history_id = $row['order_history_id'];
+	    if(!array_key_exists($order_history_id, $histories)){
+	        $histories[$order_history_id] = [
+	            'order_history_id' => $row['order_history_id'],
+	            'bought_at' => $row['bought_at'],
+	            'total_price' => $row['price'],
+	        ];
+	    }else{
+	        $histories[$order_history_id]['total_price'] += $row['price'];
 	    }
-	}*/
+	}
+	$responce['history'] = $histories;
+
 
 	if (empty($response['history'])) {
 		$response['error_msg'] = '注文履歴はありません';
 	}
 
 	require_once DIR_VIEW . 'history.php';
+}
+
+
+function pre($rows){
+    print('<pre>');
+    print_r($rows);
+    print('</pre>');
 }
 
 function history_list($db, $user_id){
@@ -57,32 +74,6 @@ FROM
     return $row;
 }
 
-/*function history_total_price($db, $user_id) {
-
-    $stmt = $db->prepare(
- 'SELECT
-order_history_id
-(price * amount) as total_price
-FROM
-  log_items
-JOIN
-  order_histories
- ON order_histories.order_history_id = log_items.order_history_id
- WHERE user_id = ?');
-
-    $stmt->bindValue(1,(int)$user_id,PDO::PARAM_INT);
-    $stmt->execute();
-    if ($stmt->rowCount() === 0) {
-        return array();
-    }
-
-    $row = $stmt->fetchAll(PDO::FETCH_ASSOC);
-    if (empty($row)) {
-        return null;
-    }
-
-    return $row['total_price'];
-}*/
 
 function history_item($db, $user_id){
     $stmt = $db->prepare(

--- a/webroot/receipt.php
+++ b/webroot/receipt.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * @license CC BY-NC-SA 4.0
+ * @license https://creativecommons.org/licenses/by-nc-sa/4.0/deed.ja
+ * @copyright CodeCamp https://codecamp.jp
+ */
+require_once '../lib/config/const.php';
+
+require_once DIR_MODEL . 'function.php';
+
+{
+    session_start();
+
+    $response = array();
+    $result = array();
+    $db = db_connect();
+
+    check_logined($db);
+
+    $response['history'] = history_item($db, $_SESSION['user']['id']);
+    $result = array_keys(array_column($response['history'], 'order_history_id'),$_POST['id']);
+    //$result =  $response['history'][$keyIndex];
+    var_dump($result);
+
+    if (empty($_POST['id'])) {
+        $response['error_msg'] = 'リクエストが不適切です。';
+        return;
+    }
+
+    require_once DIR_VIEW . 'receipt.php';
+}
+
+/**
+ * @param PDO $db
+ * @param array $response
+ */
+function history_item($db, $user_id){
+    $stmt = $db->prepare(
+        'SELECT
+  order_histories.order_history_id,
+  order_histories.user_id,
+  order_histories.bought_at,
+  log_items.item_name,
+  log_items.price,
+  log_items.amount,
+  (price * amount) as amount_price
+FROM
+  order_histories
+  INNER JOIN log_items
+  ON order_histories.order_history_id = log_items.order_history_id
+  WHERE  order_histories.user_id = ?');
+    $stmt->bindValue(1,(int)$user_id,PDO::PARAM_INT);
+    $stmt->execute();
+    if ($stmt->rowCount() === 0) {
+        return array();
+    }
+
+    $row = $stmt->fetchAll(PDO::FETCH_ASSOC);
+    if (empty($row)) {
+        return null;
+    }
+
+    return $row;
+}

--- a/webroot/receipt.php
+++ b/webroot/receipt.php
@@ -15,22 +15,22 @@ require_once DIR_MODEL . 'function.php';
     $result = array();
     $db = db_connect();
     $sum = 0;
-    $order_history_id = $_POST['id'];
-    $bought_time = $_POST['time'];
+    $order_history_id = $_GET['id'];
+    $bought_time = $_GET['time'];
 
 
     check_logined($db);
 
-    $response['history'] = history_item($db, $_POST['id']);
+    $response['history'] = history_item($db, $_GET['id']);
 
 
 
-    if (empty($_POST['id'])) {
+    if (empty($_GET['id'])) {
         $response['error_msg'] = 'リクエストが不適切です。';
         return;
     }
 
-    if (empty($_POST['time'])) {
+    if (empty($_GET['time'])) {
         $response['error_msg'] = 'リクエストが不適切です。';
         return;
     }


### PR DESCRIPTION
# 概要
注文履歴画面と購入明細書ページの表示

# 変更内容
注文履歴画面
・対象のユーザーが過去に購入した注文が一覧で表示される
・注文番号（ECサイト側で採番する。主に管理用）、購入日時、合計金額が項目として表示する
・各行ごとに「領収書／購入明細書」のボタンを表示する。
・複数の注文がある場合は、注文が新しいものが上に来るように並び替えする。

購入明細書/領収書
・該当の注文の注文番号、購入日時、合計金額を表示すること
　・購入した商品名、商品価格、購入個数、小計を、該当の注文で購入した商品分すべて表示すること

# 影響範囲
- ナビバーに履歴ページ追加

# 補足
- SELECT文のバインド処理も行いました。